### PR TITLE
Fixes #4

### DIFF
--- a/lib/plugins/EPrints/MetaField/Orcid.pm
+++ b/lib/plugins/EPrints/MetaField/Orcid.pm
@@ -75,7 +75,7 @@ sub validate_orcid
                 my $rem = $total % 11;
                 my $res = (12 - $rem) % 11;
                 $res = $res == 10 ? "X" : $res;
-                if( $res != $digits[15] )
+                if( ($res eq 'X' && $digits[15] ne 'X') || ($res =~ /\d/ && $res != $digits[15]) )
                 {
                         push @problems, $session->html_phrase( "validate:invalid_orcid_checksum" );
                 }


### PR DESCRIPTION
Check-digit can be numeric or 'X' (so we can't use only numeric comparisons).