### PR TITLE
Subclass reports

### DIFF
--- a/cfg/cfg.d/z_orcid_support.pl
+++ b/cfg/cfg.d/z_orcid_support.pl
@@ -18,14 +18,14 @@ use EPrints::ORCID::Utils;
 
 #Enable the plugin!
 $c->{plugins}{"Orcid"}{params}{disable} = 0;
-$c->{plugins}{"Screen::Report::Orcid::UserOrcid"}{params}{disable} = 0;
-$c->{plugins}{"Screen::Report::Orcid::AllUsersOrcid"}{params}{disable} = 0;
-$c->{plugins}{"Screen::Report::Orcid::CreatorsOrcid"}{params}{disable} = 0;
+$c->{plugins}{"Screen::Report::User::Orcid::UserOrcid"}{params}{disable} = 0;
+$c->{plugins}{"Screen::Report::User::Orcid::AllUsersOrcid"}{params}{disable} = 0;
+$c->{plugins}{"Screen::Report::EPrint::EPrint::Orcid::CreatorsOrcid"}{params}{disable} = 0;
 $c->{plugins}{"Export::Report::CSV::CreatorsOrcid"}{params}{disable} = 0;
 
 #---Users---#
-#add orcid field to the user profile's 
-#but checking first to see if the field is already present in the user dataset before adding it 
+#add orcid field to the user profile's
+#but checking first to see if the field is already present in the user dataset before adding it
 my $orcid_present = 0;
 for(@{$c->{fields}->{user}})
 {
@@ -63,7 +63,7 @@ foreach my $field( @{$c->{fields}->{eprint}} )
 				last;
 		        }
 		}
-		
+
 		#add orcid subfield
 		if( !$orcid_present )
 		{
@@ -74,9 +74,9 @@ foreach my $field( @{$c->{fields}->{eprint}} )
         		                input_cols => 19,
                         	 	allow_null => 1,
 	                        }
-			));	
+			));
 		}
-	}	
+	}
 }
 
 #automatic update of eprint creator field
@@ -117,7 +117,7 @@ $c->add_dataset_trigger( 'eprint', EPrints::Const::EP_TRIGGER_BEFORE_COMMIT, sub
 		$eprint->set_value("creators", \@new_creators);
 	}
 
-	
+
 }, priority => 50 );
 
 #automatic update of eprint editor field
@@ -158,7 +158,7 @@ $c->add_dataset_trigger( 'eprint', EPrints::Const::EP_TRIGGER_BEFORE_COMMIT, sub
 		$eprint->set_value("editors", \@new_editors);
 	}
 
-	
+
 }, priority => 50 );
 
 
@@ -166,21 +166,21 @@ $c->add_dataset_trigger( 'eprint', EPrints::Const::EP_TRIGGER_BEFORE_COMMIT, sub
 {
 package EPrints::Script::Compiled;
 use strict;
- 
+
 sub run_people_with_orcids
 {
 	my( $self, $state, $value ) = @_;
- 
+
 	my $session = $state->{session};
 	my $r = $state->{session}->make_doc_fragment;
- 
+
 	my $creators = $value->[0];
- 
+
 	foreach my $i (0..$#$creators)
 	{
- 
+
 		my $creator = @$creators[$i];
- 
+
 		if( $i > 0 )
 		{
 			#not first item (or only one item)
@@ -194,14 +194,14 @@ sub run_people_with_orcids
 			        $r->appendChild( $session->make_text( ", " ) );
 			}
 		}
- 
+
 		my $person_span = $session->make_element( "span", "class" => "person" );
 		$person_span->appendChild( $session->render_name( $creator->{name} ) );
- 
+
 		my $orcid = $creator->{orcid};
 		if( defined $orcid && $orcid =~ m/^(?:orcid.org\/)?(\d{4}\-\d{4}\-\d{4}\-\d{3}(?:\d|X))$/ )
 		{
-			my $orcid_link = $session->make_element( "a", 
+			my $orcid_link = $session->make_element( "a",
 				"class" => "orcid",
 				"href" => "https://orcid.org/$1",
 				"target" => "_blank",
@@ -209,10 +209,10 @@ sub run_people_with_orcids
 			$orcid_link->appendChild( $session->make_element( "img", "src" => "/images/orcid_16x16.png" ) );
 
 			my $orcid_span = $session->make_element( "span", "class" => "orcid-tooltip" );
-	
+
 			$orcid_span->appendChild( $session->make_text( "ORCID: " ) );
 			$orcid_span->appendChild( $session->make_text( "https://orcid.org/$1" ) );
-			$orcid_link->appendChild( $orcid_span );			 
+			$orcid_link->appendChild( $orcid_span );
 
 			$person_span->appendChild( $session->make_text( " " ) );
 			$person_span->appendChild( $orcid_link );

--- a/lib/lang/de/phrases/orcid_reports.xml
+++ b/lib/lang/de/phrases/orcid_reports.xml
@@ -2,17 +2,15 @@
 <!DOCTYPE phrases SYSTEM "entities.dtd">
 <epp:phrases xmlns="http://www.w3.org/1999/xhtml" xmlns:epp="http://eprints.org/ep3/phrase" xmlns:epc="http://eprints.org/ep3/control">
 
-<epp:phrase id="Plugin/Screen/Report/Orcid:title">ORCID Dashboard</epp:phrase>
-
 <!-- Users with an ORCID -->
-<epp:phrase id="Plugin/Screen/Report/Orcid/UserOrcid:title">Benutzer mit einer ORCID</epp:phrase>
+<epp:phrase id="Plugin/Screen/Report/User/Orcid/UserOrcid:title">Benutzer mit einer ORCID</epp:phrase>
 <epp:phrase id="user_with_orcid"><epc:pin name="orcid" /></epp:phrase>
 
 <!-- Creators with an ORCID -->
-<epp:phrase id="Plugin/Screen/Report/Orcid/CreatorsOrcid:title">Autoren mit einer ORCID</epp:phrase>
+<epp:phrase id="Plugin/Screen/Report/EPrint/Orcid/CreatorsOrcid:title">Autoren mit einer ORCID</epp:phrase>
 
 <!-- All users with and without ORCIDs -->
-<epp:phrase id="Plugin/Screen/Report/Orcid/AllUsersOrcid:title">Alle Benutzer mit und ohne ORCIDs</epp:phrase>
+<epp:phrase id="Plugin/Screen/Report/User/Orcid/AllUsersOrcid:title">Alle Benutzer mit und ohne ORCIDs</epp:phrase>
 <epp:phrase id="creator_with_orcid"><epc:pin name="creator" /> - <epc:pin name="orcid" /></epp:phrase>
 <epp:phrase id="creator_no_orcid"><epc:pin name="creator" /> - Keine ORCID</epp:phrase>
 
@@ -21,4 +19,3 @@
 <epp:phrase id="exportfields:orcid_user">Benutzer</epp:phrase>
 
 </epp:phrases>
-

--- a/lib/lang/en/phrases/orcid_reports.xml
+++ b/lib/lang/en/phrases/orcid_reports.xml
@@ -2,17 +2,15 @@
 <!DOCTYPE phrases SYSTEM "entities.dtd">
 <epp:phrases xmlns="http://www.w3.org/1999/xhtml" xmlns:epp="http://eprints.org/ep3/phrase" xmlns:epc="http://eprints.org/ep3/control">
 
-<epp:phrase id="Plugin/Screen/Report/Orcid:title">ORCID Dashboard</epp:phrase>
-
 <!-- Users with an ORCID -->
-<epp:phrase id="Plugin/Screen/Report/Orcid/UserOrcid:title">Users with an ORCID</epp:phrase>
+<epp:phrase id="Plugin/Screen/Report/User/Orcid/UserOrcid:title">Users with an ORCID</epp:phrase>
 <epp:phrase id="user_with_orcid"><epc:pin name="orcid" /></epp:phrase>
 
 <!-- Creators with an ORCID -->
-<epp:phrase id="Plugin/Screen/Report/Orcid/CreatorsOrcid:title">Creators with an ORCID</epp:phrase>
+<epp:phrase id="Plugin/Screen/Report/EPrint/Orcid/CreatorsOrcid:title">Creators with an ORCID</epp:phrase>
 
 <!-- All users with and without ORCIDs -->
-<epp:phrase id="Plugin/Screen/Report/Orcid/AllUsersOrcid:title">All users with and without ORCIDs</epp:phrase>
+<epp:phrase id="Plugin/Screen/Report/User/Orcid/AllUsersOrcid:title">All users with and without ORCIDs</epp:phrase>
 <epp:phrase id="creator_with_orcid"><epc:pin name="creator" /> - <epc:pin name="orcid" /></epp:phrase>
 <epp:phrase id="creator_no_orcid"><epc:pin name="creator" /> - No ORCID</epp:phrase>
 
@@ -21,4 +19,3 @@
 <epp:phrase id="exportfields:orcid_user">User</epp:phrase>
 
 </epp:phrases>
-

--- a/lib/plugins/EPrints/Plugin/Screen/Report/EPrint/Orcid.pm
+++ b/lib/plugins/EPrints/Plugin/Screen/Report/EPrint/Orcid.pm
@@ -1,7 +1,7 @@
-package EPrints::Plugin::Screen::Report::Orcid;
+package EPrints::Plugin::Screen::Report::EPrint::OrcidEPrint;
 
-use EPrints::Plugin::Screen::Report;
-our @ISA = ( 'EPrints::Plugin::Screen::Report' );
+use EPrints::Plugin::Screen::Report::EPrint;
+our @ISA = ( 'EPrints::Plugin::Screen::Report::EPrint' );
 
 use strict;
 
@@ -14,6 +14,10 @@ sub new
         $self->{appears} = [];
         $self->{report} = 'orcid';
         $self->{disable} = 1;
+        $self->{show_compliance} = 0;
+        $self->{datasetid} = 'archive';
+        $self->{custom_order} = '-title/creators_name';
+        $self->{labels} = { outputs => "eprints" };
 
         return $self;
 }
@@ -35,4 +39,3 @@ sub filters
 
         return \@filters;
 }
-

--- a/lib/plugins/EPrints/Plugin/Screen/Report/EPrint/Orcid/CreatorsOrcid.pm
+++ b/lib/plugins/EPrints/Plugin/Screen/Report/EPrint/Orcid/CreatorsOrcid.pm
@@ -1,8 +1,8 @@
-package EPrints::Plugin::Screen::Report::Orcid::CreatorsOrcid;
+package EPrints::Plugin::Screen::Report::EPrint::Orcid::CreatorsOrcid;
 
-use EPrints::Plugin::Screen::Report::Orcid;
+use EPrints::Plugin::Screen::Report::EPrint::Orcid;
 
-our @ISA = ( 'EPrints::Plugin::Screen::Report::Orcid' );
+our @ISA = ( 'EPrints::Plugin::Screen::Report::EPrint::Orcid' );
 
 use strict;
 
@@ -12,16 +12,7 @@ sub new
 
         my $self = $class->SUPER::new( %params );
 
-        $self->{datasetid} = 'archive';
-        $self->{custom_order} = '-title/creators_name';
         $self->{report} = 'orcid-creators';
-
-	$self->{show_compliance} = 0;
-
-	$self->{labels} = {
-                outputs => "eprints"
-        };
-
 
         return $self;
 }
@@ -116,5 +107,3 @@ sub validate_dataobj
 
         return @problems;
 }
-
-                       

--- a/lib/plugins/EPrints/Plugin/Screen/Report/User/Orcid.pm
+++ b/lib/plugins/EPrints/Plugin/Screen/Report/User/Orcid.pm
@@ -1,0 +1,52 @@
+package EPrints::Plugin::Screen::Report::User::Orcid;
+
+use EPrints::Plugin::Screen::Report::User;
+our @ISA = ( 'EPrints::Plugin::Screen::Report::User' );
+
+use strict;
+
+sub new
+{
+        my( $class, %params ) = @_;
+
+        my $self = $class->SUPER::new( %params );
+
+        $self->{datasetid} = 'user';
+        $self->{custom_order} = '-name';
+        $self->{appears} = [];
+        $self->{report} = 'orcid';
+        $self->{disable} = 1;
+        $self->{show_compliance} = 0;
+
+        $self->{labels} = { outputs => "users" };
+
+        $self->{exportfields} = {
+                    orcid_user => [ qw(
+                            userid
+                            username
+                            email
+                            name
+                            orcid
+                    )],
+            };
+
+        return $self;
+}
+
+sub can_be_viewed
+{
+        my( $self ) = @_;
+
+        return 1;
+
+        return $self->allow( 'admin' );
+}
+
+sub filters
+{
+        my( $self ) = @_;
+
+        my @filters = @{ $self->SUPER::filters || [] };
+
+        return \@filters;
+}

--- a/lib/plugins/EPrints/Plugin/Screen/Report/User/Orcid/AllUsersOrcid.pm
+++ b/lib/plugins/EPrints/Plugin/Screen/Report/User/Orcid/AllUsersOrcid.pm
@@ -1,7 +1,7 @@
-package EPrints::Plugin::Screen::Report::Orcid::AllUsersOrcid;
+package EPrints::Plugin::Screen::Report::User::Orcid::AllUsersOrcid;
 
-use EPrints::Plugin::Screen::Report::Orcid;
-our @ISA = ( 'EPrints::Plugin::Screen::Report::Orcid' );
+use EPrints::Plugin::Screen::Report::User::Orcid;
+our @ISA = ( 'EPrints::Plugin::Screen::Report::User::Orcid' );
 
 use strict;
 
@@ -11,24 +11,7 @@ sub new
 
         my $self = $class->SUPER::new( %params );
 
-        $self->{datasetid} = 'user';
-        $self->{custom_order} = '-name';
         $self->{report} = 'orcid-all-users';
-
-	$self->{labels} = {
-                outputs => "users"
-        };
-
-	$self->{exportfields} = {
-                orcid_user => [ qw(
-                        userid
-                        username
-                        email
-                        name
-                        orcid
-                )],
-        };
-
 
         return $self;
 }
@@ -77,7 +60,7 @@ sub validate_dataobj
         }
         return @problems;
 }
- 
+
 sub bullet_points
 {
         my( $self, $user ) = @_;
@@ -85,11 +68,11 @@ sub bullet_points
         my $repo = $self->{repository};
 
         my @bullets;
- 
+
 	if( $user->is_set( "orcid" ) )
 	{
  		push @bullets, EPrints::XML::to_string( $repo->html_phrase( "user_with_orcid", orcid => $repo->xml->create_text_node( $user->get_value( "orcid" ) ) ) );
 	}
 
         return @bullets;
-}                      
+}

--- a/lib/plugins/EPrints/Plugin/Screen/Report/User/Orcid/UserOrcid.pm
+++ b/lib/plugins/EPrints/Plugin/Screen/Report/User/Orcid/UserOrcid.pm
@@ -1,7 +1,7 @@
-package EPrints::Plugin::Screen::Report::Orcid::UserOrcid;
+package EPrints::Plugin::Screen::Report::User::Orcid::UserOrcid;
 
-use EPrints::Plugin::Screen::Report::Orcid;
-our @ISA = ( 'EPrints::Plugin::Screen::Report::Orcid' );
+use EPrints::Plugin::Screen::Report::User::Orcid;
+our @ISA = ( 'EPrints::Plugin::Screen::Report::User::Orcid' );
 
 use strict;
 
@@ -11,25 +11,7 @@ sub new
 
         my $self = $class->SUPER::new( %params );
 
-        $self->{datasetid} = 'user';
-        $self->{custom_order} = '-name';
         $self->{report} = 'orcid-user';
-
-	$self->{show_compliance} = 0;
-
-	$self->{labels} = {
-                outputs => "users"
-        };
-
-	$self->{exportfields} = {
-                orcid_user => [ qw(
-			userid
-			username
-			email
-			name
-			orcid
-                )],
-	};
 
         return $self;
 }
@@ -115,5 +97,3 @@ sub bullet_points
 
         return @bullets;
 }
-
-                       


### PR DESCRIPTION
Kind of fixes [this](https://github.com/eprints/orcid_support_advance/issues/35) since now sort fields and group fields are inherited from parent classes and thereby from archive config, which renders the orcid reports more coherent with the rest of the archive.