### PR TITLE
Rudimental Context Awareness - code and citations.

### DIFF
--- a/cfg/cfg.d/z_orcid_support.pl
+++ b/cfg/cfg.d/z_orcid_support.pl
@@ -1,6 +1,6 @@
 =pod
 
-=head1 Orcid Support
+=head1 ORCID Support
 
 ORCID Support Plugin
 
@@ -123,22 +123,208 @@ $c->add_dataset_trigger( 'eprint', EPrints::Const::EP_TRIGGER_BEFORE_COMMIT, sub
 
 #Rendering ORCIDs
 {
+######################################################################
+#
+# EPrints::Script::Compiled
+#
+######################################################################
+#
+#
+######################################################################
+
+=pod
+
+=head1 NAME
+
+B<EPrints::Script::Compiled> - Namespace for EPrints::Script functions.
+
+=cut
+
+=head1 DESCRIPTION
+
+Additional function being added
+to L<EPrints::Script::Compiled>
+at the archive level via C<z_orcid_support.pl>
+for ORCID support.
+
+=cut
+
 package EPrints::Script::Compiled;
-use strict;
+use     strict;
+use     feature qw(fc); # Available in Perl 5.16 or higher.
+                        # Folds case for UTF-8 / Unicode friendly case insensitive comparisons.
+                        # https://perldoc.perl.org/perlfunc#fc
+
+use     Scalar::Util qw(blessed);
+
+=head1 SUBROUTINES
+
+=over
+
+=item run_people_with_orcids(creators);
+
+Synopsis:
+
+    # Use in a citation:
+    <epc:print expr="people_with_orcids(creators)"/>
+
+    # Alternatively:
+    <epc:print expr="people_with_orcids(editors)"/>
+
+Takes a list of people (creators, editors, etc),
+decides whether to display an ORCID,
+depending on the context,
+and the existence of a valid ORCID for that person,
+and if so handles the rendering of names and ORCID numbers and badges.
+
+Returns an anonymous array reference containing
+at index 0 an XHTML document fragment (specifically
+an L<XML::LibXML::DocumentFragment> object),
+and at index 1 the string 'XHTML'
+- presumably to identify the nature of what is at index 0.
+
+This subroutine requires additional files:
+
+=over
+
+=item cfg/citations/eprint/orcid_for_coversheet.xml
+
+This file is how the ORCID link should be rendered in coversheet tag context.
+
+=item cfg/citations/eprint/orcid_for_csv.xml
+
+This file is how the ORCID link should be rendered in csv file context.
+This only ensures a correct ORCID link.
+Additional processing of the citation may still be required
+to strip excess white space from the citation overall before use in a csv file.
+
+=item cfg/citations/eprint/orcid_for_email.xml
+
+This file is how the ORCID link should be rendered in email context.
+
+=item cfg/citations/eprint/orcid_for_web.xml
+
+This file is how the ORCID link should be rendered in web page context.
+
+=back
+
+Strings passed from this subroutine...
+
+    # Simplified example - current code isn't exactly like this:
+    my  $citation_params = {
+        string  =>  'The text that makes up our string',
+    };
+
+    my  $xhtml  =   $item->render_citation($citation_name, %{$citation_params});
+
+...should be accessed in the citation as...
+
+    # Within a html/xml/xhtml tag's attribute:
+    <tag attribute="{$string.as_string()}"></tag>   # For example only.
+                                                    # No such xhtml tag as 'tag'.
+
+    # Or standalone:
+    <epc:print expr="$string.as_string()"/>
+
+The C<as_string()> function
+may be needed to avoid
+the error:
+C<[No type for value 'The text that makes up our string' from '$string']>.
+
+For more info on EPScript Functions, see:
+L<https://wiki.eprints.org/w/EPScript/Functions>
+
+Should you edit these citation files,
+and have the commandline tool C<xmllint>,
+then it is recommended you check the files
+are valid xml after editing,
+by running from the commandline:
+
+    # Individually:
+
+    xmllint orcid_for_coversheet.xml
+
+    xmllint orcid_for_csv.xml
+
+    xmllint orcid_for_email.xml
+
+    xmllint orcid_for_web.xml
+
+    # All at once:
+
+    xmllint orcid_for*.xml
+
+Those examples assume
+you are already in the correct directory,
+typically C<< /opt/eprints3/archives/archive_name/cfg/citations/eprint >>
+where C<archive_name> is the name of your repository folder.
+
+If C<xmllint> concludes your file has no problems,
+it will output the file contents.
+
+Web page context is assumed by default,
+unless a C<render_citation>,
+C<render_citation_link> or C<render_citation_link_staff>
+method call is made with the
+C<< for_use_in => $value >> argument / option / parameter given,
+where C<$value> can be (case insensitive)
+C<csv>, C<coversheet>, C<email> or C<web>, as such:
+    
+    # On an item that can render a citation ($eprint, $user, etc):
+    $eprint->render_citation($citation_style, for_use_in => 'email');
+
+This subroutine uses the fc feature, available in Perl version 5.16 and above,
+and may need to be altered to run on lower Perl versions.
+
+=back
+
+=cut
+
 
 sub run_people_with_orcids
 {
-    my( $self, $state, $value ) = @_;
+    my( $self, $state, $value ) =   @_;
 
-    my $session = $state->{session};
-    my $r = $state->{session}->make_doc_fragment;
+    my  $repository             =   $state->{session};
+    my  $item                   =   $state->{item};
+    my  $for_use_in             =   $state->{for_use_in}?   $state->{for_use_in}:
+                                    q{};
+    my  $r                      =   $repository->make_doc_fragment;
 
+    
+    # Regular Expressions:
+    my  $captures_valid_orcid   =   qr!
+                                        ^               # Start of string
+                                        (?:orcid.org/)? # Optional non-capturing orcid.org/
+                                        (?<orcid>       # Start 'orcid' capturing group...
+                                            \d{4}\-     # Four digits and a dash
+                                            \d{4}\-     # Four digits and a dash
+                                            \d{4}\-     # Four digits and a dash
+                                            \d{3}       # Three digits
+                                            (?:\d|X)    # another digit or the letter X
+                                        )               # ...end capturing group.
+                                        $               # End of String.
+                                    !x;                 # x flag - allow white space and comments as above.
+    my  $matches_export_related =   qr!
+                                        (               # Start logical group...
+                                            exportview  # Matches exportview  
+                                            |           # ...or...
+                                            export_     # Matches export_
+                                            |           # ...or...
+                                            cgi/export/ # Matches cgi/export/
+                                        )               # ...End logical group.
+                                    !x;                 # x flag - allow white space and comments as above.
+    my  $matches_yes            =   qr/^(y|yes)$/i;     # case insensitive y or yes and an exact match - no partial matches like yesterday.
+                                                        # Originally used to assess a yaml toggle to determine $email_display_setting value.
+
+    # Processing:
+    
     my $contributors = $value->[0];
     my $field = $value->[1];
 
     my $f = $field->get_property( "fields_cache" );
     my $browse_links = {};
-    my $views = $session->config( "browse_views" );
+    my $views = $repository->config( "browse_views" );
 
     foreach my $sub_field ( @{$f} )
     {
@@ -157,7 +343,7 @@ sub run_people_with_orcids
     foreach my $i ( 0..$#$contributors )
     {
         my $contributor = @$contributors[$i];
-        my $url = $session->config( "rel_path" );
+        my $url = $repository->config( "rel_path" );
 
         my $contributors = $value->[0];
 
@@ -167,22 +353,22 @@ sub run_people_with_orcids
             if( $i == $#$contributors )
             {
                 # last item
-                $r->appendChild( $session->make_text( " and " ) );
+                $r->appendChild( $repository->make_text( " and " ) );
             }
             else
             {
-                $r->appendChild( $session->make_text( ", " ) );
+                $r->appendChild( $repository->make_text( ", " ) );
             }
         }
 
-        my $person_span = $session->make_element( "span", "class" => "person" );
+        my $person_span = $repository->make_element( "span", "class" => "person" );
 
         # only looking for browse_link in the name sub field for now... 
         if( defined( $browse_links->{name} ) )
         {
             my $linkview = $browse_links->{name}->{view};
             my $sub_field = $browse_links->{name}->{field};
-            my $link_id = $sub_field->get_id_from_value( $session, $contributor->{name} );
+            my $link_id = $sub_field->get_id_from_value( $repository, $contributor->{name} );
 
             if(
                 ( defined $linkview->{fields} && $linkview->{fields} =~ m/,/ ) ||
@@ -200,42 +386,143 @@ sub run_people_with_orcids
                 EPrints::Utils::escape_filename( $link_id ).
                 ".html";
             }
-            my $a = $session->render_link( $url );
-            $a->appendChild( $session->render_name( $contributor->{name} ) );
+            my $a = $repository->render_link( $url );
+            $a->appendChild( $repository->render_name( $contributor->{name} ) );
             $person_span->appendChild( $a );
         }
         else
         {
-            $person_span->appendChild( $session->render_name( $contributor->{name} ) );
+            $person_span->appendChild( $repository->render_name( $contributor->{name} ) );
         }
 
- 
-        my $orcid = $contributor->{orcid};
-        my $uri = "";
-        $uri = $session->get_request->uri if defined $session->get_request;
-        if( $uri !~ m/exportview/ && $uri !~ m!/export_! && $uri !~ m!/cgi/export/! && defined $orcid && $orcid =~ m/^(?:orcid.org\/)?(\d{4}\-\d{4}\-\d{4}\-\d{3}(?:\d|X))$/ )
+
+        # SHOWING ORCID:
+
+        # Initial Values: 
+        my  $default_display_setting        =   1;  # 1 to Show ORCIDs by default
+                                                    # i.e. if not "for use in" any special context
+                                                    # via (for_use_in => 'special context').
+                                                    #
+                                                    # Set to 0 to prevent showing ORCIDs by default
+                                                    # in all contexts except special contexts
+                                                    # that defer to their own display setting values.
+                                                    # Final decision to show depends on value of $show_orcid variable.
+
+        my  $email_display_setting          =   1;  # Set to 0 to exclude ORCIDs from email flagged contexts.
+        my  $coversheet_display_setting     =   1;  # Set to 0 to exclude ORCIDs from coversheet flagged contexts.
+        my  $csv_display_setting            =   1;  # Set to 0 to exclude ORCIDs from csv flagged contexts.
+
+        my  $valid_orcid                    =   defined $contributor->{orcid}
+                                                && ($contributor->{orcid} =~ $captures_valid_orcid)?    $+{orcid}:
+                                                undef;
+
+        my  $uri                            =   defined $repository->get_request?                       $repository->get_request->uri:
+                                                q{};
+
+        my  $uri_not_export_related         =   $uri !~ $matches_export_related;
+
+        my  $display_setting                =   (fc $for_use_in) eq (fc 'email')?                       $email_display_setting:
+                                                (fc $for_use_in) eq (fc 'coversheet')?                  $coversheet_display_setting:
+                                                (fc $for_use_in) eq (fc 'csv')?                         $csv_display_setting:
+                                                $default_display_setting; # Fallback.
+
+        my  $show_orcid                     =   $uri_not_export_related
+                                                && $valid_orcid
+                                                && $display_setting;
+
+        # Processing:                         
+        if ($show_orcid)
         {
-            my $orcid_link = $session->make_element( "a",
-                "class" => "orcid",
-                "href" => "https://orcid.org/$1",
-                "target" => "_blank",
+            # Initial Values:
+            my  @static_folder = (
+                path                        =>  "static",
+                scheme                      =>  "https",
+                host                        =>  1,
             );
-            $orcid_link->appendChild( $session->make_element( "img", "src" => "/images/orcid_id.svg", "class" => "orcid-icon", "alt" => "ORCID logo" ) );
 
-            my $orcid_span = $session->make_element( "span", "class" => "orcid-tooltip" );
+            my  $static_folder              =   $repository->get_url(@static_folder)->abs($repository->config("base_url"));
+            my  $citation_name              =   (fc $for_use_in) eq (fc 'email')?       'orcid_for_email':
+                                                (fc $for_use_in) eq (fc 'coversheet')?  'orcid_for_coversheet':
+                                                (fc $for_use_in) eq (fc 'csv')?         'orcid_for_csv':
+                                                'orcid_for_web'; # default/fallback
+            my  $provided_citation_params   =   $state;
 
-            $orcid_span->appendChild( $session->make_text( "ORCID: " ) );
-            $orcid_span->appendChild( $session->make_text( "https://orcid.org/$1" ) );
-            $orcid_link->appendChild( $orcid_span );
+            my  $our_overriding_citation_params = {
 
-            $person_span->appendChild( $session->make_text( " " ) );
-            $person_span->appendChild( $orcid_link );
+                # Essentials required:
+                item                        =>  $item,
+                session                     =>  $repository,
+                repository                  =>  $repository,
+                in                          =>  'EPrints::Script::Compiled::run_people_with_orcids',
 
-            $person_span->setAttribute( "class", "person orcid-person" );
+                # Values for use in citations:
+                valid_orcid                 =>  $valid_orcid,   # Access in citation as {$valid_orcid.as_string()}
+                static_folder               =>  $static_folder, # Access in citation as {$static_folder.as_string()}
+
+            };
+
+            my  $citation_params            =   {
+                                                    %{$provided_citation_params},
+                                                    %{$our_overriding_citation_params},
+                                                };
+
+            # Processing:
+            my  $orcid_link                 =   $item->render_citation($citation_name, %{$citation_params});
+            my  $valid_orcid_link           =   $orcid_link
+                                                && Scalar::Util::blessed($orcid_link)
+                                                && $orcid_link->isa('XML::LibXML::DocumentFragment')
+                                                && $orcid_link->can('hasChildNodes')
+                                                && $orcid_link->hasChildNodes;
+
+            # Output:
+            if ($valid_orcid_link) {
+                $person_span->appendChild( $repository->make_text( " " ) );
+                $person_span->appendChild( $orcid_link );
+
+                $person_span->setAttribute( "class", "person orcid-person" );
+            };
         }
+        
+        # Output per contributor:
         $r->appendChild( $person_span );
     }
+
+    # Final output:
     return [ $r, "XHTML" ];
 }
 
 }
+
+=head1 COPYRIGHT
+
+=for COPYRIGHT BEGIN
+
+Copyright 2024 University of Southampton.
+EPrints 3.4 is supplied by EPrints Services.
+
+http://www.eprints.org/eprints-3.4/
+
+=for COPYRIGHT END
+
+=head1 LICENSE
+
+=for LICENSE BEGIN
+
+This file is part of EPrints 3.4 L<http://www.eprints.org/>.
+
+EPrints 3.4 and this file are released under the terms of the
+GNU Lesser General Public License version 3 as published by
+the Free Software Foundation unless otherwise stated.
+
+EPrints 3.4 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with EPrints 3.4.
+If not, see L<http://www.gnu.org/licenses/>.
+
+=for LICENSE END
+
+=cut

--- a/cfg/citations/eprint/orcid_for_coversheet.xml
+++ b/cfg/citations/eprint/orcid_for_coversheet.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" ?>
+<cite:citation xmlns="http://www.w3.org/1999/xhtml" xmlns:cite="http://eprints.org/ep3/citation" xmlns:epc="http://eprints.org/ep3/control">
+    <epc:comment>
+        This is an xml snippet used by EPrints::Script::Compiled::run_people_with_orcids
+        which is a subroutine in the EPrints::Script::Compiled package namespace,
+        added to the namespace at the local archive level via inclusion
+        in the file z_orcid_support.pl in the cfg/cfg.d folder
+        - i.e. cfg/cfg.d/z_orcid_support.pl
+
+        The xml snippet below is used to dictate how an ORCID link is rendered.
+        It governs the presentation of the link to orcid.org via a badge,
+        that is rendered next to a person's name.
+        It does not govern the presentation of a person's name.
+
+        This citation is only used by method calls to
+        render_citation, render_citation_link or render_citation_link_staff,
+        that include a...
+
+            for_use_in => 'coversheet',
+
+        ...argument / option / parameter.
+        For example:
+
+            $eprint->render_citation($citation_style, for_use_in => 'coversheet');
+
+        When using strings passed as citation arguments in the citation below,
+        it is better to use {$string.as_string()} instead of simply {$string},
+        in order to avoid the error:
+        [No type for value 'Some stuff inside string' from '$string']
+    </epc:comment>
+    ORCID: https://orcid.org/<epc:print expr="$valid_orcid.as_string()"/>
+</cite:citation>

--- a/cfg/citations/eprint/orcid_for_csv.xml
+++ b/cfg/citations/eprint/orcid_for_csv.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" ?>
+<cite:citation xmlns="http://www.w3.org/1999/xhtml" xmlns:cite="http://eprints.org/ep3/citation" xmlns:epc="http://eprints.org/ep3/control">
+    <epc:comment>
+        This is an xml snippet used by EPrints::Script::Compiled::run_people_with_orcids
+        which is a subroutine in the EPrints::Script::Compiled package namespace,
+        added to the namespace at the local archive level via inclusion
+        in the file z_orcid_support.pl in the cfg/cfg.d folder
+        - i.e. cfg/cfg.d/z_orcid_support.pl
+
+        The xml snippet below is used to dictate how an ORCID link is rendered.
+        It governs the presentation of the link to orcid.org via a badge,
+        that is rendered next to a person's name.
+        It does not govern the presentation of a person's name.
+
+        This citation is only used by method calls to
+        render_citation, render_citation_link or render_citation_link_staff,
+        that include a...
+
+            for_use_in => 'csv',
+
+        ...argument / option / parameter.
+        For example:
+
+            $eprint->render_citation($citation_style, for_use_in => 'csv');
+
+        When using strings passed as citation arguments in the citation below,
+        it is better to use {$string.as_string()} instead of simply {$string},
+        in order to avoid the error:
+        [No type for value 'Some stuff inside string' from '$string']
+    </epc:comment>
+    ORCID: https://orcid.org/<epc:print expr="$valid_orcid.as_string()"/>
+</cite:citation>

--- a/cfg/citations/eprint/orcid_for_email.xml
+++ b/cfg/citations/eprint/orcid_for_email.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" ?>
+<cite:citation xmlns="http://www.w3.org/1999/xhtml" xmlns:cite="http://eprints.org/ep3/citation" xmlns:epc="http://eprints.org/ep3/control">
+    <epc:comment>
+        This is an xml snippet used by EPrints::Script::Compiled::run_people_with_orcids
+        which is a subroutine in the EPrints::Script::Compiled package namespace,
+        added to the namespace at the local archive level via inclusion
+        in the file z_orcid_support.pl in the cfg/cfg.d folder
+        - i.e. cfg/cfg.d/z_orcid_support.pl
+
+        The xml snippet below is used to dictate how an ORCID link is rendered.
+        It governs the presentation of the link to orcid.org via a badge,
+        that is rendered next to a person's name.
+        It does not govern the presentation of a person's name.
+
+        This citation is only used by method calls to
+        render_citation, render_citation_link or render_citation_link_staff,
+        that include a...
+
+            for_use_in => 'email',
+
+        ...argument / option / parameter.
+        For example:
+
+            $eprint->render_citation($citation_style, for_use_in => 'email');
+
+        When using strings passed as citation arguments in the citation below,
+        it is better to use {$string.as_string()} instead of simply {$string},
+        in order to avoid the error:
+        [No type for value 'Some stuff inside string' from '$string']
+    </epc:comment>
+    <a class="orcid" href="https://orcid.org/{$valid_orcid.as_string()}" target="_blank">
+        <img src="{$static_folder.as_string()}/images/orcid_id.svg" class="orcid-icon" alt="ORCID: https://orcid.org/{$valid_orcid.as_string()}" width="16" height="16" style="border: 0; padding-right: 0px; margin-right: 5px; width: 16px; height: 16px; vertical-align: bottom;"/>
+    </a>
+</cite:citation>

--- a/cfg/citations/eprint/orcid_for_web.xml
+++ b/cfg/citations/eprint/orcid_for_web.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" ?>
+<cite:citation xmlns="http://www.w3.org/1999/xhtml" xmlns:cite="http://eprints.org/ep3/citation" xmlns:epc="http://eprints.org/ep3/control">
+    <epc:comment>
+        This is an xml snippet used by EPrints::Script::Compiled::run_people_with_orcids
+        which is a subroutine in the EPrints::Script::Compiled package namespace,
+        added to the namespace at the local archive level via inclusion
+        in the file z_orcid_support.pl in the cfg/cfg.d folder
+        - i.e. cfg/cfg.d/z_orcid_support.pl
+
+        The xml snippet below is used to dictate how an ORCID link is rendered.
+        It governs the presentation of the link to orcid.org via a badge,
+        that is rendered next to a person's name.
+        It does not govern the presentation of a person's name.
+
+        It is assumed this citation will be used in web page renderings.
+
+        For example:
+
+            $eprint->render_citation($citation_style); # Will use orcid_for_web.xml by default.
+
+        A flag can be passed to any method rendering a citation,
+        to indicate a different context.
+
+        For example:
+
+            $eprint->render_citation($citation_style, for_use_in => 'email'); # Will use orcid_for_email.xml by default.
+
+        So far, email, coversheet and csv are the other recognised contexts,
+        for which you will wish to look at their respective files:
+        cfg/citations/eprint/orcid_for_email.xml
+        cfg/citations/eprint/orcid_for_coversheet.xml
+        cfg/citations/eprint/orcid_for_csv.xml
+
+        When using strings passed as citation arguments within the citation below,
+        it is better to use {$string.as_string()} instead of simply {$string},
+        in order to avoid the error:
+        [No type for value 'Some stuff inside string' from '$string']
+    </epc:comment>
+    <a class="orcid" href="https://orcid.org/{$valid_orcid.as_string()}" target="_blank">
+        <img src="{$static_folder.as_string()}/images/orcid_id.svg" class="orcid-icon" alt="ORCID logo"/>
+        <span class="orcid-tooltip">ORCID: https://orcid.org/<epc:print expr="$valid_orcid.as_string()"/></span>
+    </a>
+</cite:citation>


### PR DESCRIPTION
At EPrints Services,
I had a few support tickets,
that involved context-aware ORCID link rendering,
and implemented a rudimentary means to achieve this,
by passing a 'for_use_in' key and corresponding value,
as parameters/options to render citation calls (described in the POD and xml epc comments of this pull request).

Following this, I've been advised to raise a Git Issue to discuss if the ORCID Support plugin should be updated to have some notion of context awareness: https://github.com/eprints/orcid_support/issues/32#issue-2136452592

Do you think it should have some notion of context awareness?

I've forked the ORCID Support repository and created a new branch to show the kind of change(s) I had made in my support tickets.

A new or different approach could be taken,
or what I have done could be improved upon to deliver an ideal result.

Changes include:

* Additional POD and comments within #Rendering ORCIDs section.

* Tab spacing on 'use' statements to align with package statement.

* Additional use of fc and blessed,
via feature pragma on Perl 5.16 and higher, 
and Scalar::Util packages respectively.

* Changes to initial variables:
$repository instead of $session; 
$item and $for_use_in declared/defined;
Some regular expressions defined.

* Replacement of $session with $repository.

* $uri definition refactored to ternary style.

* $orcid replaced with $valid_orcid (validated against a regex).

* Long-winded if statement, replaced with simply: if ($show_orcid).

* Initial creation of orcid link removed.

* Initial creation of static folder parameters for a get_url method added.

* Append child statements for an ORCID link replaced with a validated return value from a render citation call. Validation includes a check for child nodes as a means to ensuring non-empty xhtml. I am unsure if this is the best approach for that purpose.

* Original ORCID Link updates to $person_span now occur only if we have a $valid_orcid_link.

Regarding discussions and improvements...

'for_use_in' could perhaps be more specific - orcid_link_rendering_intent or orcid_link_for_use_in, or orcid_link_context;
or something broad could be adopted by EPrints across all render_citation calls.
Perhaps the mandatory 'in' from $state was originally intended to be used to derive context from, and could be adapted?

While working on the rudimentary means to achieve context-awareness for an ORCID link, I was hopping into z_orcid_support.pl and editing it multiple times, simply to change an ORCID link. Is an ORCID link a candidate for an object, and thus z_orcid_support could be left alone, and merely call a class to obtain a new ORCID link object instance as needed?

There are a bunch of display toggles in my rudimentary version.
A colleague has suggested in future, these toggles could be in config values set within cfg/cfg.d.
At an earlier stage, these were set using YAML config files, taking advantage of CPAN::Meta::YAML being in Perl Core since Perl 5.14 via the following:

```
use CPAN::Meta::YAML qw(LoadFile); # Standard module in Core Perl since Perl 5.14
my  $matches_yes            =   qr/^(y|yes)$/i; # case insensitive y or yes and an exact match - no partial matches like yesterday.
my  $email_display_setting  =   -e $repository->config('archiveroot').'/cfg/orcid_in_email.yml'
                                && (LoadFile($repository->config('archiveroot').'/cfg/orcid_in_email.yml')->{'Show ORCID In Email'} =~ $matches_yes);
```

```
# Example YAML Configuration File for email_display_setting:
%YAML 1.2
---
Show ORCID In Email: yes
...
```

On Perl 5.14 the YAML file needed a clearly indicated YAML document end via either a blank line at the end of the file, or a '...' rather than simply ending with an end of file and no blank line. Perl 5.16 didn't seem to care as much.

Email clients can be years behind web browsers. When rendering for an email context, consider whether linking to an svg file or more traditional gif or png incarnations of the ORCID ID badge image is more appropriate. A free trial of litmus could be used to make an assessment: https://www.litmus.com/email-previews
Email image embedding is not presently an option since EPrints Core does not currently implement content id headers for file attachments, and that could be changed.

The rudimental approach in this pull request currently requires a series of xml citation files to exist in cfg/citations/eprint/ 
Rather than all possibilities always being required to be accounted for with xml files,
a more dynamic approach could be taken. Similar to how a citation style is simply the filename of the citation to look for, there could be similar flexibility, allowing the xml citation files to be created as and when needed, rather than ever-present.
A middle ground would be a set of basic ones assumed to be present,
with more able to be created as needed.

The use of the fc feature for folded case comparisons,
means this rudimentary approach requires Perl 5.16 or higher.
That may or may not be desired,
and could be easily solved by requiring exact case sensitive matches.

I've used the standard EPrints POD footer, and its copyright notices,
and am unsure if that's appropriate for forks of this that will appear on the eprintsug / EPrints User Group.

The default behaviour is web page context.
Default assumptions may need to be discussed and decided upon.

As such, there is lots to discuss as regards the best way forwards,
with this as a starting point for these discussions.


