### PR TITLE
Adjust the tooltip arrow and fix tooltip fading on Safari

### DIFF
--- a/lib/static/style/auto/orcid_support.css
+++ b/lib/static/style/auto/orcid_support.css
@@ -22,8 +22,9 @@
 }
 
 .orcid:hover .orcid-tooltip{
-	visibility: visible;
 	opacity: 1;
+	transition: opacity 0.3s;
+	pointer-events: all;
 }
 
 .orcid img{
@@ -31,13 +32,11 @@
 }
 
 .orcid-tooltip{
-	visibility: hidden;
 	position: absolute;
 	left: -85px;
 	bottom: -35px;
 	z-index: 1;
 	opacity: 0;
-	transition: opacity 0.3s;
 	background-color: #A6CE39;
 	border: 1px solid #000000;
 	white-space: pre;
@@ -46,6 +45,7 @@
 	padding: 5px;
 	color: #fff;
 	border-radius: 5px;
+	pointer-events: none;
 }
 
 .orcid-tooltip::before {

--- a/lib/static/style/auto/orcid_support.css
+++ b/lib/static/style/auto/orcid_support.css
@@ -33,7 +33,7 @@
 
 .orcid-tooltip{
 	position: absolute;
-	left: -85px;
+	left: -130px;
 	bottom: -35px;
 	z-index: 1;
 	opacity: 0;
@@ -51,7 +51,7 @@
 .orcid-tooltip::before {
     content: "";
     position: absolute;
-    top: 100%;
+    top: -29px;
     left: 50%;
     height: 18px;
     margin-left: -5px;

--- a/lib/static/style/auto/orcid_support.css
+++ b/lib/static/style/auto/orcid_support.css
@@ -29,6 +29,11 @@
 
 .orcid img{
 	vertical-align: bottom;
+	/* Prevent its tooltip from being copied with the text */
+	user-select: none;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
 }
 
 .orcid-tooltip{
@@ -45,7 +50,12 @@
 	padding: 5px;
 	color: #fff;
 	border-radius: 5px;
+	/* Act akin to `visibility: hidden` without actually changing visibility */
 	pointer-events: none;
+	user-select: none;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
 }
 
 .orcid-tooltip::before {


### PR DESCRIPTION
The arrow above the ORCID tooltip (when you hover over 'iD') was adjusted in 21bae97 to make it consistent across browsers however it also shifted it well away from the button itself ([see this comment](https://github.com/eprints/orcid_support/commit/21bae97991ef132f0ed9ce87307fec57af43332e#commitcomment-28287207)), so this moves it back while ensuring it still works across Chrome, Firefox, Safari and Edge.

When you hover over the 'iD' button there is a 0.3s opacity transition to fade the tooltip in however on Safari this wouldn't fade the text, instead that would appear jarringly at the end of the transition. This appears to be a quirk of how setting `visibility` interacts with `transition opacity` on text so to fix it I removed the `visibility` setting in favour of `pointer-events: none` (and `user-select: none` to prevent accidental copy-pasting).

As a final fix this also prevents the 'iD' icon from being selected as otherwise when you copy a row of authors it adds a bunch of `[ORCID logo]` strings to the copied text.